### PR TITLE
Fixes an issue with a regexp that was causing the parser to miss messages

### DIFF
--- a/Parser.js
+++ b/Parser.js
@@ -23,7 +23,7 @@ var fs = require('fs'),
 		// Modes: $1 = time, $2 = modes, $3 = moder
 		mode: /^(\d\d:\d\d(?::\d\d)?)-!- (?:ServerM|m)ode\/\S+ \[([^\]]+)\] by (\S*)$/,
 		// Regular messages: $1 = time, $2 = mode, $3 = nick, $4 = message
-		message: /^(\d\d:\d\d(?::\d\d)?)<(.)([^>]+)> (.*)$/,
+		message: /^(\d\d:\d\d(?::\d\d)?) <(.)([^>]+)> (.*)$/,
 		// Actions: $1 = time, $2 = nick, $3 = message
 		action: /^(\d\d:\d\d(?::\d\d)?) \* (\S+) (.*)$/
 	},


### PR DESCRIPTION
Hi kfranqueiro!

Forgive me if i'm incorrect. When using your node-irssi-log-parser's bin/export-json, it was not outputting any chat messages. It was outputting pretty much everything else, including actions. I've since made a simple change to the "message" regex; adding a space:

old regexp:
^(\d\d:\d\d(?::\d\d)?)<(.)([^>]+)> (.*)$
matches:
09:10@adarq yo jr

new regexp:
^(\d\d:\d\d(?::\d\d)?) <(.)([^>]+)> (.*)$
matches:
09:10 @adarq yo jr

All of the irssi log files I have seen use the latter format (with the space). If somehow your log files lack the space char, then we can change the regexp to have an optional space. If that is the case, please let me know & I will PR that if you want.

Thanks!
